### PR TITLE
Docker Optimization + Client Artifact Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *nlog
 
 docker/web/webroot/*
+docker/web/artifacts.json
+docker/web/dist.zip
 */.Dockerfile.swp*
 
 ### C/C++ Ignores

--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,14 +1,10 @@
-#FROM ubuntu as pullsql
-#WORKDIR /sql
-
-FROM debian AS curl
-RUN apt-get update && apt-get install -y curl
-WORKDIR /curldata
-RUN curl https://gist.githubusercontent.com/DominikWiesner/571a858c927cc1a6f3275c939a503f05/raw/97f43550598778a4736fc2885d97f1bdd901c47f/mediacontent.sql > populate.sql
-RUN curl https://gist.githubusercontent.com/niklasstich/cedf71bb4294808249da5f486cf12fdf/raw/ce7a72f141cb22b1ecf237f51805000cb7eafa7a/login.sql > login.sql
-
 FROM bitnami/mariadb
 ENV MYSQL_DATABASE=mediacontent
 ENV MARIADB_ROOT_PASSWORD=rootpasswd
-COPY --from=curl /curldata/*.sql /docker-entrypoint-initdb.d/
+USER root
+RUN apt-get update && apt-get install -y curl
+WORKDIR /docker-entrypoint-initdb.d
+RUN curl https://gist.githubusercontent.com/DominikWiesner/571a858c927cc1a6f3275c939a503f05/raw/97f43550598778a4736fc2885d97f1bdd901c47f/mediacontent.sql > populate.sql
+RUN curl https://gist.githubusercontent.com/niklasstich/cedf71bb4294808249da5f486cf12fdf/raw/ce7a72f141cb22b1ecf237f51805000cb7eafa7a/login.sql > login.sql
+RUN curl https://gist.githubusercontent.com/michaelpezke/bb0158dc9a95bb10d59b740f9bb0c9cf/raw/4d35387eeb411dcc448f1a4ab0aabe6b39bad5b7/alreadytranscodedmpd.sql > alreadytranscodedmpd.sql
 EXPOSE 3306

--- a/docker/web/.dockerignore
+++ b/docker/web/.dockerignore
@@ -1,0 +1,1 @@
+webroot

--- a/docker/web/get_latest_client_artifact.sh
+++ b/docker/web/get_latest_client_artifact.sh
@@ -1,0 +1,6 @@
+GITHUB_USER=""
+GITHUB_TOKEN=""
+
+curl -sS -u "$GITHUB_USER":"$GITHUB_TOKEN" https://api.github.com/repos/hske-streaming-server/media-streaming-client/actions/artifacts > artifacts.json
+FAKEDL=$(jq '.artifacts | max_by(.id) | .archive_download_url' artifacts.json | tr -d '"')
+curl -sS -u "$GITHUB_USER":"$GITHUB_TOKEN" -L "$FAKEDL" -o dist.zip

--- a/docker/web/get_latest_client_artifact.sh
+++ b/docker/web/get_latest_client_artifact.sh
@@ -1,10 +1,10 @@
 GITHUB_USER="niklasstich"
-GITHUB_TOKEN="d47a66ffde5feeacebb860c933d78f327120de5e"
+GITHUB_TOKEN="64f4ad0aeea3c719a1f280eb9a1d3dc0753a2502"
 
 sudo apt update
 sudo apt install -y curl jq unzip
 curl -sS -u "$GITHUB_USER":"$GITHUB_TOKEN" https://api.github.com/repos/hske-streaming-server/media-streaming-client/actions/artifacts > artifacts.json
-FAKEDL=$(jq '.artifacts | max_by(.id) | .archive_download_url' artifacts.json | tr -d '"')
+FAKEDL=$(jq '[.artifacts[] | select(.name=="dist_master")] | max_by(.id) | .archive_download_url' artifacts.json | tr -d '"')
 curl -sS -u "$GITHUB_USER":"$GITHUB_TOKEN" -L "$FAKEDL" -o dist.zip
 rm ./webroot -rf
 mkdir webroot

--- a/docker/web/get_latest_client_artifact.sh
+++ b/docker/web/get_latest_client_artifact.sh
@@ -1,6 +1,11 @@
-GITHUB_USER=""
-GITHUB_TOKEN=""
+GITHUB_USER="niklasstich"
+GITHUB_TOKEN="d47a66ffde5feeacebb860c933d78f327120de5e"
 
+sudo apt update
+sudo apt install -y curl jq unzip
 curl -sS -u "$GITHUB_USER":"$GITHUB_TOKEN" https://api.github.com/repos/hske-streaming-server/media-streaming-client/actions/artifacts > artifacts.json
 FAKEDL=$(jq '.artifacts | max_by(.id) | .archive_download_url' artifacts.json | tr -d '"')
 curl -sS -u "$GITHUB_USER":"$GITHUB_TOKEN" -L "$FAKEDL" -o dist.zip
+rm ./webroot -rf
+mkdir webroot
+unzip dist.zip -d webroot

--- a/docker/web/get_latest_client_artifact.sh
+++ b/docker/web/get_latest_client_artifact.sh
@@ -1,4 +1,4 @@
-GITHUB_USER="niklasstich"
+GITHUB_USER=""
 GITHUB_TOKEN=""
 
 sudo apt update

--- a/docker/web/get_latest_client_artifact.sh
+++ b/docker/web/get_latest_client_artifact.sh
@@ -1,5 +1,5 @@
 GITHUB_USER="niklasstich"
-GITHUB_TOKEN="d47a66ffde5feeacebb860c933d78f327120de5e"
+GITHUB_TOKEN=""
 
 sudo apt update
 sudo apt install -y curl jq unzip


### PR DESCRIPTION
- Docker Container etwas aufgeräumt und Layer reduziert. Erster Build kann wieder ein wenig dauern, aber alle Builds danach sollten noch etwas schneller und kleiner sein.
- Skript hinzugefügt, zieht das Artifact vom letzten Push auf master und entpackt es in webroot.
Unter Windows ausführbar mit WSL + Ubuntu (Windows Store): ```wsl ./get_latest_client_artifact.sh```